### PR TITLE
Move the CFP close date to August 15

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -76,7 +76,7 @@ params:
 
   # Call for Speakers (Sessionize CFP) — rendered as the "cfp" section
   CFP:
-    status: "Open · submissions close July 31"
+    status: "Open · submissions close August 15"
     submitLink: "https://sessionize.com/gophercon-israel-2026/"
     intro: "We're looking for a diverse range of sessions for both newcomers and seasoned Gophers. This year we're focused on building AI systems — but there's plenty more we'd love to hear about. Sessions should bring practical, real-world takeaways the audience can apply."
     topics:
@@ -90,7 +90,7 @@ params:
       - "Community projects"
     dates:
       - { label: "CFP opens", date: "June 29" }
-      - { label: "CFP closes", date: "July 31 · 11:59pm" }
+      - { label: "CFP closes", date: "August 15 · 11:59pm" }
       - { label: "Notifications", date: "September 1" }
       - { label: "Schedule announced", date: "September 13" }
       - { label: "Dry-run sessions", date: "October 14–15" }

--- a/docs/index.html
+++ b/docs/index.html
@@ -174,7 +174,7 @@
 
 <div class="cfp-head reveal">
   <h2 class="section-title">Call for Speakers</h2>
-  <span class="cfp-status"><span class="cfp-status-dot"></span>Open · submissions close July 31</span>
+  <span class="cfp-status"><span class="cfp-status-dot"></span>Open · submissions close August 15</span>
 </div>
 
 <div class="cfp-grid">
@@ -210,7 +210,7 @@
       <li class="cfp-tl-item">
         <span class="cfp-tl-dot" aria-hidden="true"></span>
         <span class="cfp-tl-label">CFP closes</span>
-        <span class="cfp-tl-date">July 31 · 11:59pm</span>
+        <span class="cfp-tl-date">August 15 · 11:59pm</span>
       </li>
       
       <li class="cfp-tl-item">


### PR DESCRIPTION
The Sessionize CFP for GopherCon Israel 2026 closes **11:59 PM, 15 Aug 2026**, but the site still says July 31. This updates both places.

- `config.yml`: status pill text and the "CFP closes" entry in `CFP.dates`.
- `docs/index.html`: the matching strings in the committed build output, so the live Pages site shows the new date.

Source: https://sessionize.com/gophercon-israel-2026/ — "Call closes at 11:59 PM 15 Aug 2026". Note the CFP's own "Dates to remember" description still reads July 31, so that text needs a fix on Sessionize too.

I patched `docs/index.html` by hand instead of running a full `hugo` build: the committed output came from Hugo 0.115.1, and a rebuild with a current Hugo rewrites the OpenGraph tags and drops the Google Analytics snippet. The two edited lines are byte-identical to what a rebuild produces for this change.

Verified by serving `docs/` locally — the CFP section renders "Open · submissions close August 15" and "August 15 · 11:59pm".